### PR TITLE
Don't trigger click for other interactive elements

### DIFF
--- a/src/elements/clickable_card_element.js
+++ b/src/elements/clickable_card_element.js
@@ -4,7 +4,7 @@ import SprinklesElement from "./sprinkles_element";
  * A card that can be clicked anywhere to follow a link inside it
  *
  * This ensures that a screen reader does not to read the whole card to announce the link, while a user can still click anywhere in the card.
- * You can include other links and buttons in the card, these will not trigger a navigation.
+ * You can include other interactive elements in the card, these will not trigger a navigation.
  *
  * This is based on the recipe and discussion from Web Accessibility Cookbook by Manuel Matuzović (O’Reilly). Copyright 2024 Manuel Matuzović, 978-1-098-14560-6.
  * and this article from Vikas Parashar: https://css-tricks.com/block-links-the-search-for-a-perfect-solution/#aa-method-4-sprinkle-javascript-on-the-second-method
@@ -17,8 +17,12 @@ export default class ClickableCardElement extends SprinklesElement {
   };
 
   handleClick(event) {
-    // Don't handle clicks on buttons or anchors
-    if (event.target.closest(`${this.constructor.tagName} :is(a,button)`)) {
+    // Don't handle clicks on other interactive elements
+    if (
+      event.target.closest(
+        `${this.constructor.tagName} :is(a,button,summary,input,select)`,
+      )
+    ) {
       return;
     }
 


### PR DESCRIPTION
## Summary of changes
This fixes an issue where clicking on an input or a select inside a card, would also trigger the navigation.

## Checklist
<!---
  Before requesting a review, make sure to go over this checklist
  and verify that everything is ok.
  --->
- [x] All CI checks are working
- [ ] I've added tests relevant to my changes.
- [x] I've added documentation relevant to my changes.
- [ ] I've moved all hardcoded copy to translations
<!---
  If you did any manual testing as well, please mention so
  here. Provide instructions so we can reproduce those tests.
  --->
